### PR TITLE
fix: nomenclature spread vs slippage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,14 +4,14 @@ version = 4
 
 [[package]]
 name = "ahash"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -37,9 +37,9 @@ checksum = "ecb50559f19eb92f65279f9de03e4625ed0572e7564ef3de5253e13928c55266"
 
 [[package]]
 name = "anyhow"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "ark-bls12-381"
@@ -232,9 +232,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "num-traits",
 ]
@@ -283,7 +283,7 @@ checksum = "a782b93fae93e57ca8ad3e9e994e784583f5933aeaaa5c80a545c4b437be2047"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -307,7 +307,7 @@ checksum = "e01c9214319017f6ebd8e299036e1f717fa9bb6724e758f7d6fb2477599d1a29"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -420,7 +420,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -434,9 +434,9 @@ dependencies = [
 
 [[package]]
 name = "cw-multi-test"
-version = "2.3.2"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533b31c94b9e10e77e2468a2b1559aa506505d18c4e52eb64cbfc624ca876ad2"
+checksum = "1dbb5533fff9a5c3d78c963f4f97a01f485062af5f00458fd4ec97bc4669a32a"
 dependencies = [
  "anyhow",
  "bech32",
@@ -504,9 +504,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -540,7 +540,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "unicode-xid",
 ]
 
@@ -665,9 +665,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
@@ -790,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "linked-hash-map"
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "mantra-dex-std"
-version = "2.2.0"
+version = "3.0.0"
 dependencies = [
  "anybuf",
  "cosmwasm-schema",
@@ -942,7 +942,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.24",
+ "zerocopy",
 ]
 
 [[package]]
@@ -976,9 +976,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -1013,7 +1013,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1026,7 +1026,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1261,7 +1261,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1331,7 +1331,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1342,7 +1342,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1403,9 +1403,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1439,7 +1439,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1450,7 +1450,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "test-case-core",
 ]
 
@@ -1480,7 +1480,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1491,7 +1491,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1652,42 +1652,22 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
-dependencies = [
- "zerocopy-derive 0.8.24",
+ "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1707,5 +1687,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license = "MPL-2.0"
 repository = "https://github.com/MANTRA-Chain/mantrachain-rust"
 
 [workspace.dependencies]
-mantra-dex-std  = { path = "./packages/mantra-dex-std", version = "2.2.0" }
+mantra-dex-std  = { path = "./packages/mantra-dex-std", version = "3.0.0" }
 mantrachain-std = { path = "./packages/mantrachain-std", version = "0.2.0" }
 
 anybuf             = { version = "0.5.2" }

--- a/packages/mantra-dex-std/Cargo.toml
+++ b/packages/mantra-dex-std/Cargo.toml
@@ -7,7 +7,7 @@ keywords             = ["mantrachain", "mantra", "dex", "amm", "cosmwasm"]
 license.workspace    = true
 name                 = "mantra-dex-std"
 repository.workspace = true
-version              = "2.2.0"
+version              = "3.0.0"
 
 [dependencies]
 anybuf.workspace          = true

--- a/packages/mantra-dex-std/src/pool_manager.rs
+++ b/packages/mantra-dex-std/src/pool_manager.rs
@@ -171,10 +171,10 @@ pub enum ExecuteMsg {
         /// When provided, if the slippage exceeds this value, the liquidity provision will not be
         /// executed.
         slippage_tolerance: Option<Decimal>,
-        /// The maximum allowable spread between the bid and ask prices for the pool.
-        /// When provided, if the spread exceeds this value, the liquidity provision will not be
+        /// The maximum allowable slippage for the pool.
+        /// When provided, if the slippage exceeds this value, the liquidity provision will not be
         /// executed.
-        max_spread: Option<Decimal>,
+        max_slippage: Option<Decimal>,
         /// The receiver of the LP
         receiver: Option<String>,
         /// The identifier for the pool to provide liquidity for.
@@ -191,9 +191,9 @@ pub enum ExecuteMsg {
         ask_asset_denom: String,
         /// The belief price of the swap.
         belief_price: Option<Decimal>,
-        /// The maximum spread to incur when performing the swap. If the spread exceeds this value,
-        /// the swap will not be executed. Max 50%.
-        max_spread: Option<Decimal>,
+        /// The maximum allowable slippage for the pool.
+        /// When provided, if the slippage exceeds this value, the swap will not be executed.
+        max_slippage: Option<Decimal>,
         /// The recipient of the output tokens. If not provided, the tokens will be sent to the sender
         /// of the message.
         receiver: Option<String>,
@@ -216,9 +216,9 @@ pub enum ExecuteMsg {
         ///
         /// If left unspecified, tokens will be sent to the sender of the message.
         receiver: Option<String>,
-        /// The maximum spread to incur when performing the swap. If the spread exceeds this value,
-        /// the swap will not be executed. Max 50%.
-        max_spread: Option<Decimal>,
+        /// The maximum allowable slippage for the pool.
+        /// When provided, if the slippage exceeds this value, the swap will not be executed.
+        max_slippage: Option<Decimal>,
     },
     /// Updates the configuration of the contract.
     /// If a field is not specified (i.e., set to `None`), it will not be modified.
@@ -340,8 +340,8 @@ pub struct AssetDecimalsResponse {
 pub struct SimulationResponse {
     /// The return amount of the ask asset given the offer amount.
     pub return_amount: Uint128,
-    /// The spread amount of the swap.
-    pub spread_amount: Uint128,
+    /// The slippage amount of the swap.
+    pub slippage_amount: Uint128,
     /// The swap fee amount of the swap.
     pub swap_fee_amount: Uint128,
     /// The protocol fee amount of the swap.
@@ -357,8 +357,8 @@ pub struct SimulationResponse {
 pub struct ReverseSimulationResponse {
     /// The amount of the offer asset needed to get the ask amount.
     pub offer_amount: Uint128,
-    /// The spread amount of the swap.
-    pub spread_amount: Uint128,
+    /// The slippage amount of the swap.
+    pub slippage_amount: Uint128,
     /// The swap fee amount of the swap.
     pub swap_fee_amount: Uint128,
     /// The protocol fee amount of the swap.
@@ -387,8 +387,8 @@ pub struct FeatureToggle {
 pub struct SimulateSwapOperationsResponse {
     /// The return amount of the ask asset after the swap operations.
     pub return_amount: Uint128,
-    /// The spreads of the swap.
-    pub spreads: Vec<Coin>,
+    /// The slippage amounts of the swap.
+    pub slippage_amounts: Vec<Coin>,
     /// The swap fees of the swap.
     pub swap_fees: Vec<Coin>,
     /// The protocol fees of the swap.
@@ -404,8 +404,8 @@ pub struct SimulateSwapOperationsResponse {
 pub struct ReverseSimulateSwapOperationsResponse {
     /// The amount of the initial token needed to get the final token after the swap operations.
     pub offer_amount: Uint128,
-    /// The spreads of the swap.
-    pub spreads: Vec<Coin>,
+    /// The slippage amounts of the swap.
+    pub slippage_amounts: Vec<Coin>,
     /// The swap fees of the swap.
     pub swap_fees: Vec<Coin>,
     /// The protocol fees of the swap.

--- a/packages/mantra-dex-std/src/pool_manager.rs
+++ b/packages/mantra-dex-std/src/pool_manager.rs
@@ -167,14 +167,15 @@ pub enum ExecuteMsg {
     },
     /// Provides liquidity to the pool
     ProvideLiquidity {
-        /// A percentage value representing the acceptable slippage for the operation.
+        /// A percentage value representing the acceptable slippage for the add liquidity operation.
         /// When provided, if the slippage exceeds this value, the liquidity provision will not be
         /// executed.
-        slippage_tolerance: Option<Decimal>,
-        /// The maximum allowable slippage for the pool.
+        liquidity_max_slippage: Option<Decimal>,
+        /// The maximum allowable slippage for the swap before providing liquidity.
+        /// This is used when providing liquidity with a single asset.
         /// When provided, if the slippage exceeds this value, the liquidity provision will not be
         /// executed.
-        max_slippage: Option<Decimal>,
+        swap_max_slippage: Option<Decimal>,
         /// The receiver of the LP
         receiver: Option<String>,
         /// The identifier for the pool to provide liquidity for.

--- a/packages/mantra-rwa-modules/src/staking/helpers.rs
+++ b/packages/mantra-rwa-modules/src/staking/helpers.rs
@@ -39,7 +39,7 @@ pub(crate) fn get_validators(
             let n = n.unwrap_or(MIN_VALIDATORS);
             check_validators_size(active_validators.len(), n)?;
 
-            select_pseudorandom_validators(&env.block, &sender, n, &active_validators)?
+            select_pseudorandom_validators(&env.block, sender, n, &active_validators)?
         }
         DelegationStrategy::TopN(n) => {
             check_validators_size(active_validators.len(), n)?;

--- a/packages/mantra-rwa-modules/src/staking/native.rs
+++ b/packages/mantra-rwa-modules/src/staking/native.rs
@@ -114,7 +114,7 @@ pub fn delegate(
             messages.push(msg);
             attributes.push(Attribute::new(
                 "delegation",
-                &format!("validator: {:?} -> {:?}", validator, delegation),
+                format!("validator: {:?} -> {:?}", validator, delegation),
             ));
         }
     }
@@ -157,7 +157,7 @@ pub fn undelegate(
     let attributes = vec![
         Attribute::new("action", "undelegate"),
         Attribute::new("validator", validator),
-        Attribute::new("amount", &amount.to_string()),
+        Attribute::new("amount", amount.to_string()),
     ];
 
     Ok((
@@ -237,14 +237,14 @@ pub fn claim_staking_rewards(
             total_amount = total_amount.checked_add(amount)?;
             attributes.push(Attribute::new(
                 "reward",
-                &format!("{}{}", amount, bonded_denom),
+                format!("{}{}", amount, bonded_denom),
             ));
         }
     }
 
     attributes.push(Attribute::new(
         "total_reward",
-        &format!("{}{}", total_amount, bonded_denom),
+        format!("{}{}", total_amount, bonded_denom),
     ));
 
     if let Some(recipient) = recipient {

--- a/packages/mantra-rwa-modules/src/staking/tests.rs
+++ b/packages/mantra-rwa-modules/src/staking/tests.rs
@@ -72,7 +72,7 @@ fn mock_staking_rewards(deps: &mut OwnedDeps<MockStorage, MockApi, MockQuerier>,
     deps.querier.staking.update(
         "uom",
         &get_validator_list(deps.api, 5),
-        &get_delegations(&deps.api, &sender, 4),
+        &get_delegations(&deps.api, sender, 4),
     );
 }
 
@@ -438,7 +438,7 @@ fn test_delegate() {
             Attribute::new("action", "delegate"),
             Attribute::new(
                 "delegation",
-                &format!(
+                format!(
                     "validator: {:?} -> {:?}",
                     deps.api.addr_make("validator1").to_string(),
                     coin(250u128, "uom")
@@ -446,7 +446,7 @@ fn test_delegate() {
             ),
             Attribute::new(
                 "delegation",
-                &format!(
+                format!(
                     "validator: {:?} -> {:?}",
                     deps.api.addr_make("validator2").to_string(),
                     coin(250u128, "uom")
@@ -454,7 +454,7 @@ fn test_delegate() {
             ),
             Attribute::new(
                 "delegation",
-                &format!(
+                format!(
                     "validator: {:?} -> {:?}",
                     deps.api.addr_make("validator3").to_string(),
                     coin(250u128, "uom")
@@ -462,7 +462,7 @@ fn test_delegate() {
             ),
             Attribute::new(
                 "delegation",
-                &format!(
+                format!(
                     "validator: {:?} -> {:?}",
                     deps.api.addr_make("validator4").to_string(),
                     coin(250u128, "uom")
@@ -511,7 +511,7 @@ fn test_delegate() {
             Attribute::new("action", "delegate"),
             Attribute::new(
                 "delegation",
-                &format!(
+                format!(
                     "validator: {:?} -> {:?}",
                     deps.api.addr_make("validator1").to_string(),
                     coin(31u128, "uom")
@@ -519,7 +519,7 @@ fn test_delegate() {
             ),
             Attribute::new(
                 "delegation",
-                &format!(
+                format!(
                     "validator: {:?} -> {:?}",
                     deps.api.addr_make("validator2").to_string(),
                     coin(31u128, "uom")
@@ -527,7 +527,7 @@ fn test_delegate() {
             ),
             Attribute::new(
                 "delegation",
-                &format!(
+                format!(
                     "validator: {:?} -> {:?}",
                     deps.api.addr_make("validator3").to_string(),
                     coin(31u128, "uom")
@@ -535,7 +535,7 @@ fn test_delegate() {
             ),
             Attribute::new(
                 "delegation",
-                &format!(
+                format!(
                     "validator: {:?} -> {:?}",
                     deps.api.addr_make("validator4").to_string(),
                     coin(32u128, "uom")
@@ -563,8 +563,8 @@ fn test_undelegate() {
         attributes,
         vec![
             Attribute::new("action", "undelegate"),
-            Attribute::new("validator", &deps.api.addr_make("validator1").to_string()),
-            Attribute::new("amount", &amount.to_string()),
+            Attribute::new("validator", deps.api.addr_make("validator1").to_string()),
+            Attribute::new("amount", amount.to_string()),
         ]
     );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated terminology from "spread" to "slippage" throughout liquidity provision and swap operations for clearer user communication. Field names and documentation now consistently reference "slippage" without changing functionality.
- **Chores**
  - Upgraded `mantra-dex-std` package version from 2.2.0 to 3.0.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->