### PR TITLE
feat: add pool status to pool info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,24 +736,10 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",
- "mantra-dex-std 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mantra-dex-std 2.1.5",
  "osmosis-std",
  "schemars",
  "serde",
-]
-
-[[package]]
-name = "mantra-dex-std"
-version = "2.1.5"
-dependencies = [
- "anybuf",
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-ownable",
- "cw-storage-plus",
- "osmosis-std",
- "test-case",
- "uint",
 ]
 
 [[package]]
@@ -768,6 +754,20 @@ dependencies = [
  "cw-ownable",
  "cw-storage-plus",
  "osmosis-std",
+ "uint",
+]
+
+[[package]]
+name = "mantra-dex-std"
+version = "2.1.6"
+dependencies = [
+ "anybuf",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-ownable",
+ "cw-storage-plus",
+ "osmosis-std",
+ "test-case",
  "uint",
 ]
 

--- a/packages/mantra-dex-std/CHANGELOG.md
+++ b/packages/mantra-dex-std/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## v2.1.6
+
+- Added:
+  - PoolStatus to PoolInfo struct.
+  
+## v2.1.5
+
+- Added:
+  - BeforeSendHook msg to tokenfactory helpers.
+  
+## v2.1.4
+
+- Removed:
+  - Unused fields on Farm struct.
+  
+## v2.1.3
+
+- Added:
+  - `until_epoch` param to rewards query in farm manager.
+
+## v2.1.2
+
+- Added:
+  - Optional `until_epoch` param in claim function of farm manager.
+
+## v2.1.1
+
+- Use cosmwasm2_2 feature flag.
+
+## v2.1.0
+
+- Bump cosmwasm-std and other packages versions.
+
 ## v2.0.0
 
 - Added:

--- a/packages/mantra-dex-std/CHANGELOG.md
+++ b/packages/mantra-dex-std/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 - Added:
   - PoolStatus to PoolInfo struct.
-  
+  - `pool_indentifier` param to FeatureToggle struct, so features can be enabled/disabled per pool.
+
+- Removed:
+  - FeatureToggle from Config struct.
+
 ## v2.1.5
 
 - Added:

--- a/packages/mantra-dex-std/Cargo.toml
+++ b/packages/mantra-dex-std/Cargo.toml
@@ -7,7 +7,7 @@ keywords             = ["mantrachain", "mantra", "dex", "amm", "cosmwasm"]
 license.workspace    = true
 name                 = "mantra-dex-std"
 repository.workspace = true
-version              = "2.1.5"
+version              = "2.1.6"
 
 [dependencies]
 anybuf.workspace          = true

--- a/packages/mantra-dex-std/src/pool_manager.rs
+++ b/packages/mantra-dex-std/src/pool_manager.rs
@@ -115,6 +115,16 @@ pub struct PoolStatus {
     pub withdrawals_enabled: bool,
 }
 
+impl Default for PoolStatus {
+    fn default() -> Self {
+        PoolStatus {
+            swaps_enabled: true,
+            deposits_enabled: true,
+            withdrawals_enabled: true,
+        }
+    }
+}
+
 /// The contract configuration.
 #[cw_serde]
 pub struct Config {
@@ -124,8 +134,6 @@ pub struct Config {
     pub farm_manager_addr: Addr,
     /// How much it costs to create a pool. It helps prevent spamming of new pools.
     pub pool_creation_fee: Coin,
-    //  Whether or not swaps, deposits, and withdrawals are enabled
-    pub feature_toggle: FeatureToggle,
 }
 
 #[cw_serde]
@@ -221,8 +229,8 @@ pub enum ExecuteMsg {
         farm_manager_addr: Option<String>,
         /// The new fee that must be paid when a pool is created.
         pool_creation_fee: Option<Coin>,
-        /// The new feature toggles of the contract, allowing fine-tuned
-        /// control over which operations are allowed.
+        /// Toggles features for a given pool, allowing fine-tuned
+        /// control over which operations are allowed, i.e. swap, deposits, withdrawals
         feature_toggle: Option<FeatureToggle>,
     },
 }
@@ -364,12 +372,14 @@ pub struct ReverseSimulationResponse {
 /// Pool feature toggle, can control whether swaps, deposits, and withdrawals are enabled.
 #[cw_serde]
 pub struct FeatureToggle {
+    /// The identifier of the pool to toggle the status of.
+    pub pool_identifier: String,
     /// Whether or not swaps are enabled
-    pub withdrawals_enabled: bool,
+    pub withdrawals_enabled: Option<bool>,
     /// Whether or not deposits are enabled
-    pub deposits_enabled: bool,
+    pub deposits_enabled: Option<bool>,
     /// Whether or not swaps are enabled
-    pub swaps_enabled: bool,
+    pub swaps_enabled: Option<bool>,
 }
 
 /// The response for the `SimulateSwapOperations` query.

--- a/packages/mantra-dex-std/src/pool_manager.rs
+++ b/packages/mantra-dex-std/src/pool_manager.rs
@@ -78,6 +78,8 @@ pub struct PoolInfo {
     pub pool_type: PoolType,
     /// The fees for the pool.
     pub pool_fees: PoolFee,
+    /// The status of the pool
+    pub status: PoolStatus,
 }
 
 /// Possible pool types, it can be either a constant product (xyk) pool or a stable swap pool.
@@ -100,6 +102,17 @@ impl PoolType {
             PoolType::StableSwap { .. } => "StableSwap",
         }
     }
+}
+
+/// The pool status tells what actions are enabled for this pool.
+#[cw_serde]
+pub struct PoolStatus {
+    /// Whether swaps are enabled
+    pub swaps_enabled: bool,
+    /// Whether deposits are enabled
+    pub deposits_enabled: bool,
+    /// Whether withdrawals are enabled
+    pub withdrawals_enabled: bool,
 }
 
 /// The contract configuration.


### PR DESCRIPTION
This PR adds `PoolStatus` to `PoolInfo`, to signal what actions are enabled/disabled in a pool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an operational pool status indicator that displays whether swaps, deposits, and withdrawals are enabled.
  - Enhanced token and rewards functionality with additional parameters for more flexible processing and claim management.

- **Chores**
  - Updated the package version to 2.1.6 with corresponding documentation improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->