### PR TITLE
feat: mark all_balances function as deprecated

### DIFF
--- a/packages/mantrachain-std/src/types/cosmos/bank/v1beta1.rs
+++ b/packages/mantrachain-std/src/types/cosmos/bank/v1beta1.rs
@@ -1065,6 +1065,7 @@ impl<'a, Q: cosmwasm_std::CustomQuery> BankQuerier<'a, Q> {
     ) -> Result<QueryBalanceResponse, cosmwasm_std::StdError> {
         QueryBalanceRequest { address, denom }.query(self.querier)
     }
+    #[deprecated]
     pub fn all_balances(
         &self,
         address: ::prost::alloc::string::String,


### PR DESCRIPTION
CosmWasm also mark it as deprecated:
https://github.com/CosmWasm/cosmwasm/pull/2247/files#diff-147b44b69452f7630be77dd9c3c908526e4e957f8dc92531aa1b590ba30c3ef1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Deprecated a legacy balance inquiry feature to signal future changes. The current functionality remains unaffected, ensuring backward compatibility while encouraging the shift towards updated alternatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->