### PR TITLE
refactor!: add farm action to create farm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "mantra-dex-std"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anybuf",
  "cosmwasm-schema",

--- a/packages/mantra-dex-std/Cargo.toml
+++ b/packages/mantra-dex-std/Cargo.toml
@@ -7,7 +7,7 @@ keywords             = ["mantrachain", "mantra", "dex", "amm", "cosmwasm"]
 license.workspace    = true
 name                 = "mantra-dex-std"
 repository.workspace = true
-version              = "3.0.0"
+version              = "3.1.0"
 
 [dependencies]
 anybuf.workspace          = true

--- a/packages/mantra-dex-std/src/farm_manager.rs
+++ b/packages/mantra-dex-std/src/farm_manager.rs
@@ -198,10 +198,15 @@ pub struct FarmParams {
 
 #[cw_serde]
 pub enum FarmAction {
-    /// Fills a farm. If the farm doesn't exist, it creates a new one. If it exists already,
-    /// it expands it given the sender created the original farm and the params are correct.
-    Fill {
-        /// The parameters for the farm to fill.
+    /// Creates a new farm with the given parameters.
+    Create {
+        /// The parameters for the farm to create.
+        params: FarmParams,
+    },
+    /// Expands an existing farm. The farm must already exist and the sender must be the
+    /// farm owner. The farm_identifier must be provided in the params.
+    Expand {
+        /// The parameters for the farm to expand.
         params: FarmParams,
     },
     //// Closes a farm with the given identifier. If the farm has expired, anyone can


### PR DESCRIPTION
## Description and Motivation

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

This PR adds a separate action in `FarmAction` to create a farm, instead of reusing `FillFarm` for both creating and expanding.

As a side effect, the `FillFarm` action has been renamed to `ExpandFarm`. 

## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/MANTRA-Chain/mantrachain-rust/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to MANTRA!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [MANTRA's contribution guidelines](https://github.com/MANTRA-Chain/mantrachain-rust/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `just fmt`.
- [x] Clippy doesn't report any issues `just lint`.
