### PR TITLE
chore: add optional param for factory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,7 +821,7 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "mantra-claimdrop-std"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",

--- a/packages/mantra-claimdrop-std/Cargo.toml
+++ b/packages/mantra-claimdrop-std/Cargo.toml
@@ -7,7 +7,7 @@ keywords             = ["mantrachain", "mantra", "claimdrop", "airdrop", "cosmwa
 license.workspace    = true
 name                 = "mantra-claimdrop-std"
 repository.workspace = true
-version              = "1.1.2"
+version              = "1.1.3"
 
 [dependencies]
 anyhow.workspace                  = true

--- a/packages/mantra-claimdrop-std/src/msg.rs
+++ b/packages/mantra-claimdrop-std/src/msg.rs
@@ -17,6 +17,8 @@ const MAX_TYPE_LENGTH: usize = 200;
 pub struct InstantiateMsg {
     /// Owner of the contract. If not set, it is the sender of the Instantiate message.
     pub owner: Option<String>,
+    /// Optinal action in case the contract is instantiated via the claimdrop factory
+    pub action: Option<CampaignAction>,
 }
 
 #[cw_ownable_execute]


### PR DESCRIPTION
## Description and Motivation

This PR adds optinal params to be used by the factory.

<!--

    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after
    comparisons.

-->

## Related Issues

<!--

    Add the list of issues related to this PR from the [issue tracker](https://github.com/MANTRA-Chain/mantrachain-rust/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->

---

## Checklist:

<!--

    Thanks for contributing to MANTRA!

    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes,
    like this: [x].

    Make sure to follow the guidelines, so we can process this PR as fast as possible.

-->

- [x] I have read [MANTRA's contribution guidelines](https://github.com/MANTRA-Chain/mantrachain-rust/blob/main/docs/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly `just fmt`.
-[x] Clippy doesn't report any issues `just lint`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support to specify an initial campaign action when initializing via the claimdrop factory. This is backward compatible and optional.

- Chores
  - Bumped package version to 1.1.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->